### PR TITLE
Buddybuild Example: add background task using screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ xcuserdata/
 /*.gcno
 
 # End of https://www.gitignore.io/api/xcode,carthage
+
+all-the-dates.txt

--- a/buddybuild_finally.sh
+++ b/buddybuild_finally.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-printenv 
+screen -ls
+cat all-the-dates.txt
 
 # Install gems locally
 bundle install --quiet

--- a/buddybuild_postclone.sh
+++ b/buddybuild_postclone.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-screen -S buddybuild-script -d -m $(while true; do date >> all-the-dates.txt; sleep 1; done)
+screen -S buddybuild-script -d -m bash -c "while true; do date >> all-the-dates.txt; sleep 1; done"

--- a/buddybuild_postclone.sh
+++ b/buddybuild_postclone.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+screen -S buddybuild-script -d -m $(while true; do date >> all-the-dates.txt; sleep 1; done)


### PR DESCRIPTION
See the `buddybuild_postclone.sh` file: I'm running a long task that write the date to a file every second.

In the `buddybuild_finally.sh` file, I dump the content of the file and list the screens:

```
=== Running Custom Finally Step ===
    There are screens on:
    	11201..buddybuilds-Mac	(Detached)
    	2170.buddybuild-script	(Detached)
    2 Sockets in /var/folders/zs/8kd7pzhj58g2l19xw514kc_c0000gn/T/.screen.
```